### PR TITLE
0.4 develop -> develop

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -140,5 +140,5 @@
     // Whether strict whitespace rules apply.
     "white": false,
     // Specify indentation.
-    "indent": 4
+    "indent": 2
 }

--- a/index.js
+++ b/index.js
@@ -1,31 +1,32 @@
 /*───────────────────────────────────────────────────────────────────────────*\
-│  Copyright (C) 2014 eBay Software Foundation                                │
-│                                                                             │
-│                                                                             │
-│   Licensed under the Apache License, Version 2.0 (the 'License'); you may   │
-│   not use this file except in compliance with the License. You may obtain   │
-│   a copy of the License at http://www.apache.org/licenses/LICENSE-2.0       │
-│                                                                             │
-│   Unless required by applicable law or agreed to in writing, software       │
-│   distributed under the License is distributed on an 'AS IS' BASIS,         │
-│   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  │
-│   See the License for the specific language governing permissions and       │
-│   limitations under the License.                                            │
-\*───────────────────────────────────────────────────────────────────────────*/
+ │  Copyright (C) 2014 eBay Software Foundation                                │
+ │                                                                             │
+ │                                                                             │
+ │   Licensed under the Apache License, Version 2.0 (the 'License'); you may   │
+ │   not use this file except in compliance with the License. You may obtain   │
+ │   a copy of the License at http://www.apache.org/licenses/LICENSE-2.0       │
+ │                                                                             │
+ │   Unless required by applicable law or agreed to in writing, software       │
+ │   distributed under the License is distributed on an 'AS IS' BASIS,         │
+ │   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  │
+ │   See the License for the specific language governing permissions and       │
+ │   limitations under the License.                                            │
+ \*───────────────────────────────────────────────────────────────────────────*/
 /* global module: true */
 'use strict';
 module.exports = {
-	'setup': function (config, result, callback) {
-		var returnObj = result;
-		returnObj.locatex = function locatex(_locator) {
-			var locale = (result.props && result.props.locale) ? result.props.locale : 'default',
-				locatr = this.locator;
-			_locator.split('.').forEach(function (level) {
-				locatr = locatr[level];
-			});
-			return locatr[locale] || locatr['default'] || locatr;
+  'setup': function (config, nemo, callback) {
+    nemo.locatex = function locatex(_locator) {
+      var locale = (nemo.props && nemo.props.locale) ? nemo.props.locale : 'default',
+        args = Array.prototype.slice.call(arguments),
+        locatorArray = (args.length > 1) ? args : arguments[0].split('.'),
+        locatr = nemo.locator;
+      locatorArray.forEach(function (level) {
+        locatr = locatr[level];
+      });
+      return locatr[locale] || locatr['default'] || locatr;
 
-		}.bind(result);
-		callback(null, config, returnObj);
-	}
+    };
+    callback(null, config, nemo);
+  }
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nemo-locatex",
-  "version": "0.1.4",
+  "version": "0.2.0",
   "description": "Add Locale behavior to Nemo locators",
   "main": "index.js",
   "registerAs": "locatex",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nemo-locatex",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Add Locale behavior to Nemo locators",
   "main": "index.js",
   "registerAs": "locatex",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nemo-locatex",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Add Locale behavior to Nemo locators",
   "main": "index.js",
   "registerAs": "locatex",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "async": "~0.2.8"
   },
   "peerDependencies": {
-    "nemo-drivex": "^0.1.0"
+    "nemo-drivex": "^0.4.0",
+    "nemo": "^0.3.0"
   },
   "devDependencies": {
     "mocha": "~1.10.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nemo-locatex",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Add Locale behavior to Nemo locators",
   "main": "index.js",
   "registerAs": "locatex",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nemo-locatex",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Add Locale behavior to Nemo locators",
   "main": "index.js",
   "registerAs": "locatex",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "peerDependencies": {
     "nemo-drivex": "^0.4.0",
-    "nemo": "^0.3.0"
+    "nemo": "^0.4.0"
   },
   "devDependencies": {
     "mocha": "~1.10.0",


### PR DESCRIPTION
0.4 version matching up with 0.4 version of nemo-view.
* add support for arguments array to nemo.locatex
* maintain support for passing in string with dot separation (backward compatibility)
* rename local variables for clarity
* do away with unnecessary 'bind'